### PR TITLE
Add IO port statuses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY: %.eap dockerbuild 3rd-party-clean clean very-clean
 
 PROG = opcuaserver
-OBJS = opcua_server.o opcua_dbus.o opcua_open62541.o opcua_tempsensors.o
+OBJS = opcua_server.o opcua_dbus.o opcua_open62541.o opcua_tempsensors.o opcua_portsio.o
 STRIP ?= strip
 
 PKGS =  gio-2.0 glib-2.0 axparameter

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 [![GitHub Super-Linter](https://github.com/AxisCommunications/opc-ua-server-acap/actions/workflows/super-linter.yml/badge.svg)](https://github.com/AxisCommunications/opc-ua-server-acap/actions/workflows/super-linter.yml)
 
 This directory contains the source code to build a small ACAP application that
-uses D-Bus to get sensor data from `com.axis.TemperatureController` and expose
-it as [OPC UA](https://en.wikipedia.org/wiki/OPC_Unified_Architecture) with an
+uses D-Bus to get
+- temperature sensor data from `com.axis.TemperatureController`
+- IO port states from `com.axis.IOControl.State`
+and expose them as [OPC UA](https://en.wikipedia.org/wiki/OPC_Unified_Architecture) with an
 [open62541](https://open62541.org/) server. It serves as an example of how easy
 it actually is to integrate any Axis device in an OPC UA system.
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "acapPackageConf": {
         "setup": {
             "appName": "opcuaserver",
-            "friendlyName": "OPC UA Server", 
+            "friendlyName": "OPC UA Server",
             "vendor": "Axis Communications AB",
             "embeddedSdkVersion": "2.0",
             "user": {
@@ -11,7 +11,7 @@
                 "group": "root"
             },
             "runMode": "respawn",
-            "version": "1.0.2"
+            "version": "1.1.0"
         },
         "configuration": {
             "paramConfig": [

--- a/opcua_common.h
+++ b/opcua_common.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Axis Communications AB, Lund, Sweden
+ * Copyright (C) 2022 Axis Communications AB, Lund, Sweden
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/opcua_dbus.c
+++ b/opcua_dbus.c
@@ -19,17 +19,28 @@
 #include "opcua_common.h"
 #include "opcua_dbus.h"
 
+#define NO_TIMEOUT -1
 #define TEMPERATURE_DBUS_SERVICE "com.axis.TemperatureController"
 #define TEMPERATURE_DBUS_OBJECT "/com/axis/TemperatureController"
 #define TEMPERATURE_DBUS_INTERFACE "com.axis.TemperatureController"
 
-static GDBusProxy *dbusproxy;
+#define PORTS_DBUS_SERVICE "com.axis.IOControl.State"
+#define PORTS_DBUS_OBJECT "/com/axis/IOControl/State"
+#define PORTS_DBUS_INTERFACE "com.axis.IOControl.State"
+#define PORT_STATE_TRUE "true"
+#define PORT_STATE_FALSE "false"
 
-bool dbus_temp_init(void)
+static GDBusProxy *dbusproxy_temp;
+static GDBusProxy *dbusproxy_ports;
+
+bool dbus_all_init(void)
 {
-    assert(NULL == dbusproxy);
+    assert(NULL == dbusproxy_temp);
+    assert(NULL == dbusproxy_ports);
     GError *error = NULL;
-    dbusproxy = g_dbus_proxy_new_for_bus_sync(
+
+    // dbusproxy_temp
+    dbusproxy_temp = g_dbus_proxy_new_for_bus_sync(
         G_BUS_TYPE_SYSTEM,
         G_DBUS_PROXY_FLAGS_NONE,
         NULL,
@@ -38,7 +49,7 @@ bool dbus_temp_init(void)
         TEMPERATURE_DBUS_INTERFACE,
         NULL,
         &error);
-    if (NULL == dbusproxy)
+    if (NULL == dbusproxy_temp)
     {
         LOG_E(
             "%s/%s: Failed to create a proxy for accessing %s (%s)",
@@ -50,26 +61,56 @@ bool dbus_temp_init(void)
         return false;
     }
 
+    // dbusproxy_ports
+    dbusproxy_ports = g_dbus_proxy_new_for_bus_sync(
+        G_BUS_TYPE_SYSTEM,
+        G_DBUS_PROXY_FLAGS_NONE,
+        NULL,
+        PORTS_DBUS_SERVICE,
+        PORTS_DBUS_OBJECT,
+        PORTS_DBUS_INTERFACE,
+        NULL,
+        &error);
+    if (NULL == dbusproxy_ports)
+    {
+        LOG_E(
+            "%s/%s: Failed to create a proxy for accessing %s (%s)",
+            __FILE__,
+            __FUNCTION__,
+            PORTS_DBUS_OBJECT,
+            error->message);
+        g_error_free(error);
+        return false;
+    }
+
     return true;
 }
 
-void dbus_temp_cleanup(void)
+void dbus_all_cleanup(void)
 {
-    if (NULL != dbusproxy)
+    // dbusproxy_temp
+    if (NULL != dbusproxy_temp)
     {
-        g_object_unref(dbusproxy);
-        dbusproxy = NULL;
+        g_object_unref(dbusproxy_temp);
+        dbusproxy_temp = NULL;
+    }
+
+    // dbusproxy_ports
+    if (NULL != dbusproxy_ports)
+    {
+        g_object_unref(dbusproxy_ports);
+        dbusproxy_ports = NULL;
     }
 }
 
 bool dbus_temp_get_number_of_sensors(uint32_t *count)
 {
     assert(NULL != count);
-    assert(NULL != dbusproxy);
+    assert(NULL != dbusproxy_temp);
     GError *error = NULL;
 
     GVariant *result =
-        g_dbus_proxy_call_sync(dbusproxy, "GetNbrOfTemperatureSensors", NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
+        g_dbus_proxy_call_sync(dbusproxy_temp, "GetNbrOfTemperatureSensors", NULL, G_DBUS_CALL_FLAGS_NONE, NO_TIMEOUT, NULL, &error);
     if (NULL == result)
     {
         LOG_E(
@@ -99,11 +140,11 @@ bool dbus_temp_get_number_of_sensors(uint32_t *count)
 bool dbus_temp_get_value(int id, double *value)
 {
     assert(NULL != value);
-    assert(NULL != dbusproxy);
+    assert(NULL != dbusproxy_temp);
     GError *error = NULL;
 
     GVariant *result = g_dbus_proxy_call_sync(
-        dbusproxy, "GetTemperature", g_variant_new("(is)", id, "celsius"), G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
+        dbusproxy_temp, "GetTemperature", g_variant_new("(is)", id, "celsius"), G_DBUS_CALL_FLAGS_NONE, NO_TIMEOUT, NULL, &error);
     if (NULL == result)
     {
         LOG_E("%s/%s: Failed to get sensor %i temperature from D-Bus (%s)", __FILE__, __FUNCTION__, id, error->message);
@@ -128,16 +169,16 @@ bool dbus_temp_get_value(int id, double *value)
 
 bool dbus_temp_subscribe_to_change(uint32_t *subscription_id, uint32_t sensor_id, double d)
 {
-    assert(NULL != dbusproxy);
+    assert(NULL != dbusproxy_temp);
     assert(NULL != subscription_id);
     GError *error = NULL;
 
     GVariant *result = g_dbus_proxy_call_sync(
-        dbusproxy,
+        dbusproxy_temp,
         "RegisterForTemperatureChangeSignal",
         g_variant_new("(id)", sensor_id, d),
         G_DBUS_CALL_FLAGS_NONE,
-        -1,
+        NO_TIMEOUT,
         NULL,
         &error);
     if (NULL == result)
@@ -192,9 +233,182 @@ bool dbus_temp_unpack_signal(GVariant *parameters, uint32_t *subscription_id, do
     return true;
 }
 
-void dbus_connect_g_signal(GCallback func)
+void dbus_connect_temp_g_signal(GCallback func)
 {
-    assert(NULL != dbusproxy);
+    assert(NULL != dbusproxy_temp);
     assert(NULL != func);
-    g_signal_connect(dbusproxy, "g-signal", func, NULL);
+    g_signal_connect(dbusproxy_temp, "g-signal", func, NULL);
+}
+
+void dbus_connect_ports_g_signal(GCallback func)
+{
+    assert(NULL != dbusproxy_ports);
+    assert(NULL != func);
+    g_signal_connect(dbusproxy_ports, "g-signal", func, NULL);
+}
+
+/**
+ * get_number_of_ioports:
+ * @brief Get number of I/O ports from dbus.
+ * @return TRUE if successful.
+ */
+bool dbus_get_number_of_ioports(uint32_t *inputs, uint32_t *outputs)
+{
+  assert(NULL != inputs);
+  assert(NULL != outputs);
+  assert(NULL != dbusproxy_ports);
+  gboolean ret = FALSE;
+  GError *error = NULL;
+  GVariant *ret_val = NULL;
+
+  ret_val = g_dbus_proxy_call_sync(dbusproxy_ports, "GetNbrPorts", NULL, G_DBUS_CALL_FLAGS_NONE, NO_TIMEOUT, NULL, &error);
+  if (NULL == ret_val)
+  {
+    LOG_E(
+      "%s/%s: Failed to get number of ports from D-Bus (%s)",
+      __FILE__,
+      __FUNCTION__,
+      error->message
+    );
+
+    g_error_free(error);
+    g_variant_unref(ret_val);
+    return false;
+  }
+  LOG_I("%s/%s: Got number of ports response from D-Bus!", __FILE__, __FUNCTION__);
+
+  if (ret_val) {
+    g_variant_get(ret_val, "(uu)", inputs, outputs);
+    ret = TRUE;
+    g_variant_unref(ret_val);
+  }
+
+  return ret;
+}
+
+bool dbus_port_get_state(int id, bool *state)
+{
+    assert(NULL != state);
+    assert(NULL != dbusproxy_ports);
+    GError *error = NULL;
+
+    GVariant *result = g_dbus_proxy_call_sync(
+        dbusproxy_ports, "GetState", g_variant_new("(u)", id), G_DBUS_CALL_FLAGS_NONE, NO_TIMEOUT, NULL, &error);
+
+    if (NULL == result)
+    {
+        LOG_E("%s/%s: Failed to get port %i state from D-Bus (%s)", __FILE__, __FUNCTION__, id, error->message);
+        g_error_free(error);
+        g_variant_unref(result);
+        return false;
+    }
+
+    LOG_I("%s/%s: Got state response from D-Bus for port %i!", __FILE__, __FUNCTION__, id);
+
+    GVariant *gvalue = g_variant_get_child_value(result, 0);
+    if (!gvalue)
+    {
+        LOG_E("%s/%s: Failed to extract response value for port %i", __FILE__, __FUNCTION__, id);
+        g_variant_unref(result);
+        return false;
+    }
+
+    *state = g_variant_get_boolean(gvalue);
+
+    g_variant_unref(gvalue);
+    g_variant_unref(result);
+    return true;
+}
+
+bool dbus_port_unpack_signal(GVariant *parameters, uint32_t *subscription_id,
+    gint *port,
+    gboolean *virtual,
+    gboolean *hidden,
+    gboolean *input,
+    gboolean *virtual_trig,
+    gboolean *state,
+    gboolean *activelow)
+{
+    assert(NULL != parameters);
+    assert(NULL != subscription_id);
+    assert(NULL != port);
+    assert(NULL != virtual);
+    assert(NULL != hidden);
+    assert(NULL != input);
+    assert(NULL != virtual_trig);
+    assert(NULL != state);
+    assert(NULL != activelow);
+
+    // subscription or port
+    GVariant *gvalue = g_variant_get_child_value(parameters, 0);
+    if (!gvalue)
+    {
+        LOG_E("%s/%s: Failed to extract id", __FILE__, __FUNCTION__);
+        return false;
+    }
+    *subscription_id = g_variant_get_int32(gvalue);
+    *port = g_variant_get_int32(gvalue);
+    g_variant_unref(gvalue);
+
+    // virtual
+    gvalue = g_variant_get_child_value(parameters, 1);
+    if (!gvalue)
+    {
+        LOG_E("%s/%s: Failed to extract value", __FILE__, __FUNCTION__);
+        return false;
+    }
+    *virtual = g_variant_get_boolean(gvalue);
+    g_variant_unref(gvalue);
+
+    // hidden
+    gvalue = g_variant_get_child_value(parameters, 2);
+    if (!gvalue)
+    {
+        LOG_E("%s/%s: Failed to extract value", __FILE__, __FUNCTION__);
+        return false;
+    }
+    *hidden = g_variant_get_boolean(gvalue);
+    g_variant_unref(gvalue);
+
+    // input
+    gvalue = g_variant_get_child_value(parameters, 3);
+    if (!gvalue)
+    {
+        LOG_E("%s/%s: Failed to extract value", __FILE__, __FUNCTION__);
+        return false;
+    }
+    *input = g_variant_get_boolean(gvalue);
+    g_variant_unref(gvalue);
+
+    // virtual_trig
+    gvalue = g_variant_get_child_value(parameters, 4);
+    if (!gvalue)
+    {
+        LOG_E("%s/%s: Failed to extract value", __FILE__, __FUNCTION__);
+        return false;
+    }
+    *virtual_trig = g_variant_get_boolean(gvalue);
+    g_variant_unref(gvalue);
+
+    // state
+    gvalue = g_variant_get_child_value(parameters, 5);
+    if (!gvalue)
+    {
+        LOG_E("%s/%s: Failed to extract value", __FILE__, __FUNCTION__);
+        return false;
+    }
+    *state = g_variant_get_boolean(gvalue);
+    g_variant_unref(gvalue);
+
+    // activelow
+    gvalue = g_variant_get_child_value(parameters, 6);
+    if (!gvalue)
+    {
+        LOG_E("%s/%s: Failed to extract value", __FILE__, __FUNCTION__);
+        return false;
+    }
+    *activelow = g_variant_get_boolean(gvalue);
+    g_variant_unref(gvalue);
+
+    return true;
 }

--- a/opcua_dbus.h
+++ b/opcua_dbus.h
@@ -22,12 +22,18 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-bool dbus_temp_init(void);
-void dbus_temp_cleanup(void);
+bool dbus_all_init(void);
+void dbus_all_cleanup(void);
+
 bool dbus_temp_get_number_of_sensors(uint32_t *count);
 bool dbus_temp_get_value(int id, double *value);
 bool dbus_temp_subscribe_to_change(uint32_t *subscription_id, uint32_t sensor_id, double d);
 bool dbus_temp_unpack_signal(GVariant *parameters, uint32_t *subscription_id, double *value);
-void dbus_connect_g_signal(GCallback func);
+void dbus_connect_temp_g_signal(GCallback func);
+
+bool dbus_get_number_of_ioports(uint32_t *inputs, uint32_t *outputs);
+bool dbus_port_get_state(int id, bool *state);
+bool dbus_port_unpack_signal(GVariant *parameters, uint32_t *subscription_id, gint *port, gboolean *virtual, gboolean *hidden, gboolean *input, gboolean *virtual_trig, gboolean *state, gboolean *activelow);
+void dbus_connect_ports_g_signal(GCallback func);
 
 #endif /* _OPCUA_DBUS_H_ */

--- a/opcua_dbus.h
+++ b/opcua_dbus.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Axis Communications AB, Lund, Sweden
+ * Copyright (C) 2022 Axis Communications AB, Lund, Sweden
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,17 @@ bool dbus_temp_unpack_signal(GVariant *parameters, uint32_t *subscription_id, do
 void dbus_connect_temp_g_signal(GCallback func);
 
 bool dbus_get_number_of_ioports(uint32_t *inputs, uint32_t *outputs);
-bool dbus_port_get_state(int id, bool *state);
-bool dbus_port_unpack_signal(GVariant *parameters, uint32_t *subscription_id, gint *port, gboolean *virtual, gboolean *hidden, gboolean *input, gboolean *virtual_trig, gboolean *state, gboolean *activelow);
+bool dbus_port_get_state(const int id, bool *state);
+bool dbus_port_unpack_signal(
+    GVariant *parameters,
+    uint32_t *subscription_id,
+    gint *port,
+    gboolean *virtual,
+    gboolean *hidden,
+    gboolean *input,
+    gboolean *virtual_trig,
+    gboolean *state,
+    gboolean *activelow);
 void dbus_connect_ports_g_signal(GCallback func);
 
 #endif /* _OPCUA_DBUS_H_ */

--- a/opcua_open62541.c
+++ b/opcua_open62541.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Axis Communications AB, Lund, Sweden
+ * Copyright (C) 2022 Axis Communications AB, Lund, Sweden
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,54 +56,6 @@ bool ua_server_run(pthread_t *thread_id, UA_Boolean *running)
     return true;
 }
 
-void ua_server_add_double(char *label, UA_Double value)
-{
-    assert(NULL != server);
-    assert(NULL != label);
-
-    // Define attributes
-    UA_VariableAttributes attr = UA_VariableAttributes_default;
-    UA_Variant_setScalar(&attr.value, &value, &UA_TYPES[UA_TYPES_DOUBLE]);
-    attr.description = UA_LOCALIZEDTEXT("en-US", label);
-    attr.displayName = UA_LOCALIZEDTEXT("en-US", label);
-    attr.dataType = UA_TYPES[UA_TYPES_DOUBLE].typeId;
-    attr.accessLevel = UA_ACCESSLEVELMASK_READ;
-
-    // Add the variable node to the information model
-    UA_NodeId node_id = UA_NODEID_STRING(1, label);
-    UA_QualifiedName name = UA_QUALIFIEDNAME(1, label);
-    UA_NodeId parent_node_id = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
-    UA_NodeId parent_ref_node_id = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
-    UA_Server_addVariableNode(
-        server,
-        node_id,
-        parent_node_id,
-        parent_ref_node_id,
-        name,
-        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
-        attr,
-        NULL,
-        NULL);
-}
-
-void ua_server_update_temp(char *label, UA_Double value)
-{
-    assert(NULL != server);
-    UA_Variant newvalue;
-    UA_Variant_setScalar(&newvalue, &value, &UA_TYPES[UA_TYPES_DOUBLE]);
-    UA_NodeId currentNodeId = UA_NODEID_STRING(1, label);
-    UA_Server_writeValue(server, currentNodeId, newvalue);
-}
-
-void ua_server_update_port(char *label, UA_Boolean state)
-{
-    assert(NULL != server);
-    UA_Variant newvalue;
-    UA_Variant_setScalar(&newvalue, &state, &UA_TYPES[UA_TYPES_BOOLEAN]);
-    UA_NodeId currentNodeId = UA_NODEID_STRING(1, label);
-    UA_Server_writeValue(server, currentNodeId, newvalue);
-}
-
 void ua_server_add_bool(char *label, UA_Boolean state)
 {
     assert(NULL != server);
@@ -134,4 +86,52 @@ void ua_server_add_bool(char *label, UA_Boolean state)
         attr,
         NULL,
         NULL);
+}
+
+void ua_server_add_double(char *label, UA_Double value)
+{
+    assert(NULL != server);
+    assert(NULL != label);
+
+    // Define attributes
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+    UA_Variant_setScalar(&attr.value, &value, &UA_TYPES[UA_TYPES_DOUBLE]);
+    attr.description = UA_LOCALIZEDTEXT("en-US", label);
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", label);
+    attr.dataType = UA_TYPES[UA_TYPES_DOUBLE].typeId;
+    attr.accessLevel = UA_ACCESSLEVELMASK_READ;
+
+    // Add the variable node to the information model
+    UA_NodeId node_id = UA_NODEID_STRING(1, label);
+    UA_QualifiedName name = UA_QUALIFIEDNAME(1, label);
+    UA_NodeId parent_node_id = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
+    UA_NodeId parent_ref_node_id = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
+    UA_Server_addVariableNode(
+        server,
+        node_id,
+        parent_node_id,
+        parent_ref_node_id,
+        name,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+        attr,
+        NULL,
+        NULL);
+}
+
+void ua_server_update_port(char *label, UA_Boolean state)
+{
+    assert(NULL != server);
+    UA_Variant newvalue;
+    UA_Variant_setScalar(&newvalue, &state, &UA_TYPES[UA_TYPES_BOOLEAN]);
+    UA_NodeId currentNodeId = UA_NODEID_STRING(1, label);
+    UA_Server_writeValue(server, currentNodeId, newvalue);
+}
+
+void ua_server_update_temp(char *label, UA_Double value)
+{
+    assert(NULL != server);
+    UA_Variant newvalue;
+    UA_Variant_setScalar(&newvalue, &value, &UA_TYPES[UA_TYPES_DOUBLE]);
+    UA_NodeId currentNodeId = UA_NODEID_STRING(1, label);
+    UA_Server_writeValue(server, currentNodeId, newvalue);
 }

--- a/opcua_open62541.c
+++ b/opcua_open62541.c
@@ -94,3 +94,44 @@ void ua_server_update_temp(char *label, UA_Double value)
     UA_NodeId currentNodeId = UA_NODEID_STRING(1, label);
     UA_Server_writeValue(server, currentNodeId, newvalue);
 }
+
+void ua_server_update_port(char *label, UA_Boolean state)
+{
+    assert(NULL != server);
+    UA_Variant newvalue;
+    UA_Variant_setScalar(&newvalue, &state, &UA_TYPES[UA_TYPES_BOOLEAN]);
+    UA_NodeId currentNodeId = UA_NODEID_STRING(1, label);
+    UA_Server_writeValue(server, currentNodeId, newvalue);
+}
+
+void ua_server_add_bool(char *label, UA_Boolean state)
+{
+    assert(NULL != server);
+    assert(NULL != label);
+
+    // Define attributes
+    UA_VariableAttributes attr = UA_VariableAttributes_default;
+
+    UA_Variant_setScalar(&attr.value, &state, &UA_TYPES[UA_TYPES_BOOLEAN]);
+
+    attr.description = UA_LOCALIZEDTEXT("en-US", label);
+    attr.displayName = UA_LOCALIZEDTEXT("en-US", label);
+    attr.dataType = UA_TYPES[UA_TYPES_BOOLEAN].typeId;
+    attr.accessLevel = UA_ACCESSLEVELMASK_READ;
+
+    // Add the variable node to the information model
+    UA_NodeId node_id = UA_NODEID_STRING(1, label);
+    UA_QualifiedName name = UA_QUALIFIEDNAME(1, label);
+    UA_NodeId parent_node_id = UA_NODEID_NUMERIC(0, UA_NS0ID_OBJECTSFOLDER);
+    UA_NodeId parent_ref_node_id = UA_NODEID_NUMERIC(0, UA_NS0ID_ORGANIZES);
+    UA_Server_addVariableNode(
+        server,
+        node_id,
+        parent_node_id,
+        parent_ref_node_id,
+        name,
+        UA_NODEID_NUMERIC(0, UA_NS0ID_BASEDATAVARIABLETYPE),
+        attr,
+        NULL,
+        NULL);
+}

--- a/opcua_open62541.h
+++ b/opcua_open62541.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Axis Communications AB, Lund, Sweden
+ * Copyright (C) 2022 Axis Communications AB, Lund, Sweden
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@
 void ua_server_init(UA_Server *s);
 bool ua_server_run(pthread_t *thread_id, UA_Boolean *running);
 
+void ua_server_add_bool(char *label, UA_Boolean state);
 void ua_server_add_double(char *label, UA_Double value);
+void ua_server_update_port(char *label, UA_Boolean state);
 void ua_server_update_temp(char *label, UA_Double value);
 
-void ua_server_add_bool(char *label, UA_Boolean state);
-void ua_server_update_port(char *label, UA_Boolean state);
 #endif /* _OPCUA_OPEN62541_H_ */

--- a/opcua_portsio.c
+++ b/opcua_portsio.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Axis Communications AB, Lund, Sweden
+ * Copyright (C) 2022 Axis Communications AB, Lund, Sweden
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,11 +57,12 @@ char *ports_get_label_from_subscription(ports_t *ports, const uint32_t subscript
     for (size_t i = 0; i < ports->size; i++)
     {
         // Remember: Device IO Port name (referenced in the manual) starts at 1
-        if ( ports->subid[i] == subscription_id)
+        if (subscription_id == ports->subid[i])
         {
             // We have a match!
             return ports->labels[i];
         }
     }
+
     return NULL;
 }

--- a/opcua_portsio.c
+++ b/opcua_portsio.c
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2021 Axis Communications AB, Lund, Sweden
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include "opcua_portsio.h"
+
+void ports_init(ports_t **ports, const size_t size)
+{
+    assert(NULL != ports);
+    assert(NULL != *ports);
+    (*ports)->size = size;
+    (*ports)->subid = calloc(size, sizeof(uint32_t));
+    (*ports)->labels = calloc(size, sizeof(char *));
+    for (int i = 0; i < (*ports)->size; i++)
+    {
+        (*ports)->labels[i] = calloc(PORT_LABEL_LEN, sizeof(char));
+    }
+}
+
+void ports_free(ports_t **ports)
+{
+    if (NULL != ports)
+    {
+        if (NULL != *ports)
+        {
+            for (int i = 0; i < (*ports)->size; i++)
+            {
+                free((*ports)->labels[i]);
+            }
+            free((*ports)->labels);
+            free((*ports)->subid);
+        }
+    }
+}
+
+char *ports_get_label_from_subscription(ports_t *ports, const uint32_t subscription_id)
+{
+    assert(NULL != ports);
+    assert(NULL != ports->labels);
+    assert(NULL != ports->subid);
+
+    for (size_t i = 0; i < ports->size; i++)
+    {
+        // Remember: Device IO Port name (referenced in the manual) starts at 1
+        if ( ports->subid[i] == subscription_id)
+        {
+            // We have a match!
+            return ports->labels[i];
+        }
+    }
+    return NULL;
+}

--- a/opcua_portsio.h
+++ b/opcua_portsio.h
@@ -14,17 +14,24 @@
  * limitations under the License.
  */
 
-#ifndef _OPCUA_OPEN62541_H_
-#define _OPCUA_OPEN62541_H_
+#ifndef _OPCUA_PORTSIO_H_
+#define _OPCUA_PORTSIO_H_
 
-#include <open62541/server.h>
+#include <stdint.h>
+#include <stdio.h>
 
-void ua_server_init(UA_Server *s);
-bool ua_server_run(pthread_t *thread_id, UA_Boolean *running);
+#define PORT_LABEL_LEN 8
+#define PORT_LABEL_FMT "port %i"
 
-void ua_server_add_double(char *label, UA_Double value);
-void ua_server_update_temp(char *label, UA_Double value);
+typedef struct
+{
+    size_t size;
+    uint32_t *subid;
+    char **labels;
+} ports_t;
 
-void ua_server_add_bool(char *label, UA_Boolean state);
-void ua_server_update_port(char *label, UA_Boolean state);
-#endif /* _OPCUA_OPEN62541_H_ */
+void ports_init(ports_t **ports, const size_t size);
+void ports_free(ports_t **ports);
+char *ports_get_label_from_subscription(ports_t *ports, const uint32_t subscription_id);
+
+#endif /* _OPCUA_PORTSIO_H_ */

--- a/opcua_portsio.h
+++ b/opcua_portsio.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Axis Communications AB, Lund, Sweden
+ * Copyright (C) 2022 Axis Communications AB, Lund, Sweden
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/opcua_server.c
+++ b/opcua_server.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Axis Communications AB, Lund, Sweden
+ * Copyright (C) 2022 Axis Communications AB, Lund, Sweden
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@
 #include "opcua_common.h"
 #include "opcua_dbus.h"
 #include "opcua_open62541.h"
-#include "opcua_tempsensors.h"
 #include "opcua_portsio.h"
+#include "opcua_tempsensors.h"
 
 #define SIGNALTEMPCHANGE "TemperatureChangeSignal"
 #define SIGNALPORTIOCHANGE "PortChanged"
@@ -60,12 +60,16 @@ static void on_dbus_signal(
 
     // Check which signal
     // TemperatureChangeSignal
-    if (strcmp(signal_name,SIGNALTEMPCHANGE) == 0)
+    if (0 == strcmp(signal_name, SIGNALTEMPCHANGE))
     {
         if (!dbus_temp_unpack_signal(parameters, &sub_id, &value))
         {
             LOG_E(
-                "%s/%s: Failed to get values from signal %s sent by %s", __FILE__, __FUNCTION__, signal_name, sender_name);
+                "%s/%s: Failed to get values from signal %s sent by %s",
+                __FILE__,
+                __FUNCTION__,
+                signal_name,
+                sender_name);
             return;
         }
         label = tempsensors_get_label_from_subscription(&tempsensors, sub_id);
@@ -83,12 +87,17 @@ static void on_dbus_signal(
     gboolean activelow;
 
     // PortChanged
-    if (strcmp(signal_name,SIGNALPORTIOCHANGE) == 0)
+    if (0 == strcmp(signal_name, SIGNALPORTIOCHANGE))
     {
-        if (!dbus_port_unpack_signal(parameters, &sub_id, &port, &virtual, &hidden, &input, &virtual_trig, &state, &activelow))
+        if (!dbus_port_unpack_signal(
+                parameters, &sub_id, &port, &virtual, &hidden, &input, &virtual_trig, &state, &activelow))
         {
             LOG_E(
-                "%s/%s: Failed to get values from signal %s sent by %s", __FILE__, __FUNCTION__, signal_name, sender_name);
+                "%s/%s: Failed to get values from signal %s sent by %s",
+                __FILE__,
+                __FUNCTION__,
+                signal_name,
+                sender_name);
             return;
         }
 
@@ -96,7 +105,18 @@ static void on_dbus_signal(
         assert(NULL != label);
 
         ua_server_update_port(label, state);
-        LOG_I("%s/%s: Port status change. port:%d, virtual:%d, hidden:%d, input:%d, virtual_trig:%d, state:%d, activelow:%d", __FILE__, __FUNCTION__, port, virtual, hidden, input, virtual_trig, state, activelow)
+        LOG_I(
+            "%s/%s: Port status change. port:%d, virtual:%d, hidden:%d, input:%d, virtual_trig:%d, state:%d, "
+            "activelow:%d",
+            __FILE__,
+            __FUNCTION__,
+            port,
+            virtual,
+            hidden,
+            input,
+            virtual_trig,
+            state,
+            activelow)
     }
 }
 
@@ -137,25 +157,31 @@ static void add_tempsensors(void)
 
 static void add_ports(void)
 {
-    uint32_t countAll = 0;
-    uint32_t cntIn = 0;
-    uint32_t cntOut = 0;
+    uint32_t count_all = 0;
+    uint32_t count_in = 0;
+    uint32_t count_out = 0;
 
-    if (!dbus_get_number_of_ioports(&cntIn, &cntOut))
+    if (!dbus_get_number_of_ioports(&count_in, &count_out))
     {
         LOG_E("%s/%s: Failed to get number of ports", __FILE__, __FUNCTION__);
     }
     else
     {
-        countAll = cntIn + cntOut;
-        LOG_I("%s/%s: This device has %u input ports and %u output ports. (%u)", __FILE__, __FUNCTION__, cntIn, cntOut, countAll);
+        count_all = count_in + count_out;
+        LOG_I(
+            "%s/%s: This device has %u input ports and %u output ports. (%u)",
+            __FILE__,
+            __FUNCTION__,
+            count_in,
+            count_out,
+            count_all);
     }
 
     ports_t *ports_p = &ports;
-    ports_init(&ports_p, countAll);
-    assert(NULL !=ports_p);
+    ports_init(&ports_p, count_all);
+    assert(NULL != ports_p);
 
-    for (uint32_t i = 0; i < countAll; i++)
+    for (uint32_t i = 0; i < count_all; i++)
     {
         snprintf(ports.labels[i], PORT_LABEL_LEN, PORT_LABEL_FMT, i);
         LOG_I("%s/%s: Added label (%s) for port:%i", __FILE__, __FUNCTION__, ports.labels[i], i);
@@ -175,7 +201,6 @@ static void add_ports(void)
         ports.subid[i] = i;
     }
 }
-
 
 static gboolean launch_ua_server(const guint serverport)
 {

--- a/opcua_tempsensors.c
+++ b/opcua_tempsensors.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Axis Communications AB, Lund, Sweden
+ * Copyright (C) 2022 Axis Communications AB, Lund, Sweden
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/opcua_tempsensors.h
+++ b/opcua_tempsensors.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Axis Communications AB, Lund, Sweden
+ * Copyright (C) 2022 Axis Communications AB, Lund, Sweden
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Device IO Port Status

Added functionality to expose the status of any IO Ports on the device.
The exposed OPC UA nodes are Read Only. I.e no writing (setting the port) is permitted.
