### PR TITLE
README.md: Add missing newlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 
 This directory contains the source code to build a small ACAP application that
 uses D-Bus to get
+
 - temperature sensor data from `com.axis.TemperatureController`
 - IO port states from `com.axis.IOControl.State`
+
 and expose them as [OPC UA](https://en.wikipedia.org/wiki/OPC_Unified_Architecture) with an
 [open62541](https://open62541.org/) server. It serves as an example of how easy
 it actually is to integrate any Axis device in an OPC UA system.


### PR DESCRIPTION
The part with the OPC UA/open62541 part should be on its own after the
bullet list, not a part of the last bullet.
