### PR TITLE
Fix OPC UA server port configuration issue

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
                 "group": "root"
             },
             "runMode": "respawn",
-            "version": "1.1.1"
+            "version": "1.1.2"
         },
         "configuration": {
             "paramConfig": [

--- a/opcua_open62541.c
+++ b/opcua_open62541.c
@@ -33,11 +33,12 @@ static void *run_ua_server(void *running)
     return NULL;
 }
 
-void ua_server_init(UA_Server *s)
+void ua_server_init(const UA_UInt16 port)
 {
-    assert(NULL != s);
-    server = s;
-    UA_ServerConfig_setDefault(UA_Server_getConfig(server));
+    assert(NULL == server);
+    server = UA_Server_new();
+    assert(NULL != server);
+    UA_ServerConfig_setMinimal(UA_Server_getConfig(server), port, NULL);
 }
 
 bool ua_server_run(pthread_t *thread_id, UA_Boolean *running)

--- a/opcua_open62541.h
+++ b/opcua_open62541.h
@@ -19,7 +19,7 @@
 
 #include <open62541/server.h>
 
-void ua_server_init(UA_Server *s);
+void ua_server_init(const UA_UInt16 port);
 bool ua_server_run(pthread_t *thread_id, UA_Boolean *running);
 
 void ua_server_add_bool(char *label, UA_Boolean state);

--- a/opcua_server.c
+++ b/opcua_server.c
@@ -210,12 +210,7 @@ static gboolean launch_ua_server(const guint serverport)
 
     // Create an OPC UA server
     LOG_I("%s/%s: Create UA server serving on port %u", __FILE__, __FUNCTION__, serverport);
-    server = UA_Server_new();
-    if (4840 != serverport)
-    {
-        UA_ServerConfig_setMinimal(UA_Server_getConfig(server), serverport, NULL);
-    }
-    ua_server_init(server);
+    ua_server_init(serverport);
 
     // Add temperature sensors to OPA UA server
     add_tempsensors();


### PR DESCRIPTION
With port numbers that were not the default 4840 one, we would add and extra configuration instead of setting a single one with the proper port. This meant 4840 would always be used as well and is wrong.

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
