### PR TITLE
Make ACAP rootless

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,17 +1,24 @@
 {
     "schemaVersion": "1.3",
+    "resources": {
+        "dbus": {
+            "requiredMethods": [
+                "com.axis.IOControl.State.GetNbrPorts",
+                "com.axis.IOControl.State.GetState",
+                "com.axis.TemperatureController.GetNbrOfTemperatureSensors",
+                "com.axis.TemperatureController.GetTemperature",
+                "com.axis.TemperatureController.RegisterForTemperatureChangeSignal"
+            ]
+        }
+    },
     "acapPackageConf": {
         "setup": {
             "appName": "opcuaserver",
             "friendlyName": "OPC UA Server",
             "vendor": "Axis Communications AB",
             "embeddedSdkVersion": "2.0",
-            "user": {
-                "username": "root",
-                "group": "root"
-            },
             "runMode": "respawn",
-            "version": "1.1.2"
+            "version": "1.2.0"
         },
         "configuration": {
             "paramConfig": [


### PR DESCRIPTION
### Describe your changes

Specifying the specific D-Bus methods the ACAP should be allowed to use combined with not setting a specific user/group in `manifest.json` (for the ACAP framework to use a dynamic user for D-Bus) enables the ACAP to run properly as a non-privileged user.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [X] I have made corresponding changes to the documentation
