### PR TITLE
manifest.json: Explicitly set user/group

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,24 +1,17 @@
 {
     "schemaVersion": "1.3",
-    "resources": {
-        "dbus": {
-            "requiredMethods": [
-                "com.axis.IOControl.State.GetNbrPorts",
-                "com.axis.IOControl.State.GetState",
-                "com.axis.TemperatureController.GetNbrOfTemperatureSensors",
-                "com.axis.TemperatureController.GetTemperature",
-                "com.axis.TemperatureController.RegisterForTemperatureChangeSignal"
-            ]
-        }
-    },
     "acapPackageConf": {
         "setup": {
             "appName": "opcuaserver",
             "friendlyName": "OPC UA Server",
             "vendor": "Axis Communications AB",
             "embeddedSdkVersion": "2.0",
+            "user": {
+                "username": "sdk",
+                "group": "sdk"
+            },
             "runMode": "respawn",
-            "version": "1.2.1"
+            "version": "1.2.2"
         },
         "configuration": {
             "paramConfig": [


### PR DESCRIPTION
### Describe your changes

Letting the ACAP framework decide what user to run as appears not to be as reliable yet as explicitly setting the user and group in the manifest.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
