### PR TITLE
opcua_server.c: Put syslog init before signal handling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
                 "group": "sdk"
             },
             "runMode": "respawn",
-            "version": "1.2.4"
+            "version": "1.2.5"
         },
         "configuration": {
             "paramConfig": [

--- a/opcua_server.c
+++ b/opcua_server.c
@@ -356,13 +356,13 @@ static gboolean signal_handler_init(void)
 
 int main(int argc, char **argv)
 {
-    if (!signal_handler_init())
-    {
-        return -1;
-    }
-
     char *app_name = basename(argv[0]);
     open_syslog(app_name);
+
+    if (!signal_handler_init())
+    {
+        return EXIT_FAILURE;
+    }
 
     // Setup D-Bus
     LOG_I("%s/%s: Setup D-Bus", __FILE__, __FUNCTION__);
@@ -412,5 +412,5 @@ int main(int argc, char **argv)
     LOG_I("%s/%s: Closing syslog ...", __FILE__, __FUNCTION__);
     close_syslog();
 
-    return 0;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
### Describe your changes

Put syslog init before signal handling to make signal handling error logging working properly.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
