### PR TITLE
Set default workflow token permissions to read-only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   build_acap:
     name: Build ACAP packages

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -3,6 +3,9 @@ name: Lint
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   Build:
     name: Lint code base


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Token-Permissions** remedy.

It sets the default workflow token to read-only by adding a top-level `permissions` block to workflows that lacked one:

- `.github/workflows/build.yml`
- `.github/workflows/super-linter.yml`

Any job that needs more than read access must be granted those permissions at the job level, otherwise it may fail.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#token-permissions) for details.